### PR TITLE
Add Travis Slack notification settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ script:
 - python manage.py test
 notifications:
   slack: qwiz-engine:aqfFqzFlMOHT1L9AglxL2pyz
+  on_success: change
+  on_failure: always
 deploy:
   provider: heroku
   app: the-qwiz-engine


### PR DESCRIPTION
Set successful builds to only send a notification if the status changes, and always send them for failed builds.