### PR TITLE
Further Django 2.0 fixes

### DIFF
--- a/quiz/settings.py
+++ b/quiz/settings.py
@@ -52,7 +52,7 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 10
 }
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/quiz/urls.py
+++ b/quiz/urls.py
@@ -13,10 +13,9 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url, include
+from django.urls import include, path
 from rest_framework import routers
 from django.contrib import admin
-from django.views.generic import TemplateView
 from quiz import views
 
 from rest_framework_swagger.views import get_swagger_view
@@ -29,9 +28,9 @@ router.register(r'room', views.RoomViewSet)
 router.register(r'question', views.QuestionViewSet)
 
 urlpatterns = [
-    url('', views.index),
-    url('swagger/', schema_view),
-    url('api/', include(router.urls)),
-    url('api-auth', include('rest_framework.urls', namespace='rest_framework')),
-    url('admin/', admin.site.urls),
+    path('', views.index),
+    path('swagger/', schema_view),
+    path('api/', include(router.urls)),
+    path('api-auth', include('rest_framework.urls', namespace='rest_framework')),
+    path('admin/', admin.site.urls),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ chardet==3.0.4
 constantly==15.1.0
 coreapi==2.3.3
 coreschema==0.0.4
-daphne==1.3.0
+daphne==1.4.1
 dj-database-url==0.4.0
 Django==2.0.1
 django-rest-swagger==2.1.2


### PR DESCRIPTION
After upgrading to Django2 it was noticed that we could no longer reach the admin or swagger pages. Various issues were identified:
- The updated URL conf was using the incorrect pattern type
-  The Django app MIDDLEWARE setting had changed name

Also bumping the daphne version to ensure it's up to date.

Fixes #46