### PR TITLE
Fix failing Contestant websocket unittest

### DIFF
--- a/quiz/models.py
+++ b/quiz/models.py
@@ -149,7 +149,7 @@ class Room(models.Model):
         """
         message = {
             "command": "contestant_list",
-            "contestants":  [contestant.handle for contestant in self.contestant_set.all()]
+            "contestants":  sorted([contestant.handle for contestant in self.contestant_set.all()])
         }
         send_message(self.group_name(), message)
 

--- a/quiz/test_websocket.py
+++ b/quiz/test_websocket.py
@@ -127,8 +127,7 @@ class WebSocketContestantListTests(ChannelTestCase):
         self.assertDictEqual(response, {
             'command': 'contestant_list',
             'contestants': [
-                'Jane'
-                ' Doe',
+                'Jane Doe',
                 'John Doe'
             ]
         })


### PR DESCRIPTION
The Contestant model was returning an un-ordered list (as is expected)
but the unittest was expecting a particular order.
I decided to make the model return an ordered dictionary so the test
passes. It's a pretty minor change and it's not a bad thing to enforce
some sort of order on the list that the server returns.

Fixes #91